### PR TITLE
Implement Raft core leader election and replication

### DIFF
--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/AppendEntriesRequest.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/AppendEntriesRequest.java
@@ -1,0 +1,30 @@
+package io.distributed.consensus.raft.core;
+
+import java.util.List;
+
+/**
+ * AppendEntries RPC used for log replication and heartbeats.
+ */
+public record AppendEntriesRequest(NodeId source, NodeId destination, long term, long prevLogIndex,
+                                   long prevLogTerm, List<LogEntry> entries, long leaderCommit)
+        implements RaftMessage {
+
+    /**
+     * Creates a new append entries request.
+     */
+    public AppendEntriesRequest {
+        if (term < 0) {
+            throw new IllegalArgumentException("Term must be non-negative");
+        }
+        if (prevLogIndex < 0) {
+            throw new IllegalArgumentException("Previous log index must be non-negative");
+        }
+        if (prevLogTerm < 0) {
+            throw new IllegalArgumentException("Previous log term must be non-negative");
+        }
+        if (leaderCommit < 0) {
+            throw new IllegalArgumentException("Leader commit index must be non-negative");
+        }
+        entries = List.copyOf(entries);
+    }
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/AppendEntriesResponse.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/AppendEntriesResponse.java
@@ -1,0 +1,20 @@
+package io.distributed.consensus.raft.core;
+
+/**
+ * Response to an {@link AppendEntriesRequest} RPC.
+ */
+public record AppendEntriesResponse(NodeId source, NodeId destination, long term, boolean success,
+                                    long matchIndex) implements RaftMessage {
+
+    /**
+     * Creates a response object.
+     */
+    public AppendEntriesResponse {
+        if (term < 0) {
+            throw new IllegalArgumentException("Term must be non-negative");
+        }
+        if (matchIndex < 0) {
+            throw new IllegalArgumentException("Match index must be non-negative");
+        }
+    }
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/ClientResponse.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/ClientResponse.java
@@ -1,0 +1,119 @@
+package io.distributed.consensus.raft.core;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Result for a client command submitted to the Raft cluster.
+ */
+public final class ClientResponse {
+
+    /** Response status codes. */
+    public enum Status {
+        /** Command successfully committed and applied. */
+        SUCCESS,
+        /**
+         * Node is not the cluster leader. The caller should redirect the request to the provided
+         * leader hint when available.
+         */
+        NOT_LEADER,
+        /** Failure occurred during replication or shutdown. */
+        FAILURE
+    }
+
+    private final Status status;
+    private final byte[] output;
+    private final NodeId leaderHint;
+
+    private ClientResponse(final Status status, final byte[] output, final NodeId leaderHint) {
+        this.status = Objects.requireNonNull(status, "status");
+        this.output = output == null ? null : output.clone();
+        this.leaderHint = leaderHint;
+    }
+
+    /**
+     * Creates a successful response.
+     *
+     * @param output state machine output payload
+     * @return success response
+     */
+    public static ClientResponse success(final byte[] output) {
+        return new ClientResponse(Status.SUCCESS, output, null);
+    }
+
+    /**
+     * Creates a redirection response that informs the caller which node is likely the leader.
+     *
+     * @param leaderHint identifier of the known leader, may be {@code null}
+     * @return not-leader response
+     */
+    public static ClientResponse notLeader(final NodeId leaderHint) {
+        return new ClientResponse(Status.NOT_LEADER, null, leaderHint);
+    }
+
+    /**
+     * Creates a failure response.
+     *
+     * @param leaderHint best-effort leader hint, may be {@code null}
+     * @return failure response
+     */
+    public static ClientResponse failure(final NodeId leaderHint) {
+        return new ClientResponse(Status.FAILURE, null, leaderHint);
+    }
+
+    /**
+     * Returns the response status.
+     *
+     * @return status enum
+     */
+    public Status status() {
+        return status;
+    }
+
+    /**
+     * Returns the optional state machine output payload.
+     *
+     * @return response payload, or {@code null}
+     */
+    public byte[] output() {
+        return output == null ? null : output.clone();
+    }
+
+    /**
+     * Returns the best-effort leader hint included in redirection responses.
+     *
+     * @return leader identifier, may be {@code null}
+     */
+    public NodeId leaderHint() {
+        return leaderHint;
+    }
+
+    @Override
+    public String toString() {
+        return "ClientResponse{" +
+                "status=" + status +
+                ", output=" + (output == null ? "null" : output.length + " bytes") +
+                ", leaderHint=" + leaderHint +
+                '}';
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ClientResponse other)) {
+            return false;
+        }
+        return status == other.status
+                && Arrays.equals(output, other.output)
+                && Objects.equals(leaderHint, other.leaderHint);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(status, leaderHint);
+        result = 31 * result + Arrays.hashCode(output);
+        return result;
+    }
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/DefaultRaftNode.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/DefaultRaftNode.java
@@ -1,0 +1,517 @@
+package io.distributed.consensus.raft.core;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default in-memory Raft node implementation featuring leader election and log replication.
+ */
+public final class DefaultRaftNode implements RaftNode, RaftEndpoint {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRaftNode.class);
+
+    /**
+     * Role of the node inside the cluster.
+     */
+    public enum Role {
+        /** Regular follower state. */
+        FOLLOWER,
+        /** Candidate actively campaigning for leadership. */
+        CANDIDATE,
+        /** Current cluster leader responsible for log replication. */
+        LEADER
+    }
+
+    private final RaftConfig config;
+    private final StateMachine stateMachine;
+    private final RaftTransport transport;
+    private final ScheduledExecutorService scheduler;
+    private final RandomGenerator random;
+    private final AtomicInteger roleGauge;
+    private final AtomicLong termGauge;
+    private final AtomicLong commitGauge;
+    private final CompletableFuture<Void> shutdownFuture = new CompletableFuture<>();
+
+    private final RaftLog log = new RaftLog();
+    private final Map<Long, CompletableFuture<ClientResponse>> clientResponses = new HashMap<>();
+    private final Map<NodeId, Long> nextIndex = new HashMap<>();
+    private final Map<NodeId, Long> matchIndex = new HashMap<>();
+
+    private volatile Role role = Role.FOLLOWER;
+    private volatile NodeId leaderId;
+    private volatile long currentTerm;
+    private volatile NodeId votedFor;
+    private volatile int votesGranted;
+    private volatile long commitIndex;
+    private volatile long lastApplied;
+
+    private volatile long electionDeadlineNanos;
+    private volatile long heartbeatDeadlineNanos;
+    private volatile boolean running;
+    private ScheduledFuture<?> tickerTask;
+
+    /**
+     * Creates a new Raft node with the provided dependencies.
+     *
+     * @param config        immutable configuration
+     * @param stateMachine  deterministic state machine applied on commit
+     * @param transport     transport used to deliver outbound messages
+     * @param scheduler     single-threaded scheduler backing the event loop
+     * @param meterRegistry optional metrics registry, may be {@code null}
+     */
+    public DefaultRaftNode(final RaftConfig config, final StateMachine stateMachine, final RaftTransport transport,
+                           final ScheduledExecutorService scheduler, final MeterRegistry meterRegistry) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.stateMachine = Objects.requireNonNull(stateMachine, "stateMachine");
+        this.transport = Objects.requireNonNull(transport, "transport");
+        this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+        this.random = RandomGeneratorFactory.of("L64X128MixRandom").create();
+        matchIndex.put(config.localNodeId(), 0L);
+        nextIndex.put(config.localNodeId(), 1L);
+        if (meterRegistry != null) {
+            final List<Tag> tags = List.of(Tag.of("node", config.localNodeId().value()));
+            this.roleGauge = meterRegistry.gauge("raft_role", tags, new AtomicInteger(role.ordinal()));
+            this.termGauge = meterRegistry.gauge("raft_term", tags, new AtomicLong(currentTerm));
+            this.commitGauge = meterRegistry.gauge("raft_commit_index", tags, new AtomicLong(commitIndex));
+        } else {
+            this.roleGauge = null;
+            this.termGauge = null;
+            this.commitGauge = null;
+        }
+    }
+
+    /**
+     * Convenience factory using a managed single-threaded scheduler.
+     *
+     * @param config       immutable configuration
+     * @param stateMachine deterministic state machine applied on commit
+     * @param transport    transport used to deliver outbound messages
+     * @param scheduler    scheduler backing the event loop
+     * @return configured Raft node instance
+     */
+    public static DefaultRaftNode create(final RaftConfig config, final StateMachine stateMachine,
+                                         final RaftTransport transport, final ScheduledExecutorService scheduler) {
+        return new DefaultRaftNode(config, stateMachine, transport, scheduler, null);
+    }
+
+    /**
+     * Creates a node backed by a dedicated virtual-thread scheduler.
+     *
+     * @param config       immutable configuration
+     * @param stateMachine deterministic state machine applied on commit
+     * @param transport    transport used to deliver outbound messages
+     * @return configured Raft node instance
+     */
+    public static DefaultRaftNode create(final RaftConfig config, final StateMachine stateMachine,
+                                         final RaftTransport transport) {
+        final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
+                Thread.ofVirtual().name("raft-" + config.localNodeId().value() + "-", 0).factory());
+        return new DefaultRaftNode(config, stateMachine, transport, scheduler, null);
+    }
+
+    @Override
+    public synchronized void start() {
+        if (running) {
+            return;
+        }
+        running = true;
+        LOGGER.info("Starting Raft node {}", config.localNodeId());
+        resetElectionTimer();
+        heartbeatDeadlineNanos = now() + config.heartbeatInterval().toNanos();
+        tickerTask = scheduler.scheduleAtFixedRate(this::onTick, 0L, config.tickInterval().toNanos(),
+                TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public CompletableFuture<ClientResponse> apply(final byte[] command) {
+        Objects.requireNonNull(command, "command");
+        final byte[] payloadCopy = command.clone();
+        final CompletableFuture<ClientResponse> future = new CompletableFuture<>();
+        execute(() -> applyInternal(payloadCopy, future));
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Void> shutdown() {
+        execute(this::shutdownInternal);
+        return shutdownFuture;
+    }
+
+    @Override
+    public void handleMessage(final RaftMessage message) {
+        Objects.requireNonNull(message, "message");
+        execute(() -> handleMessageInternal(message));
+    }
+
+    /**
+     * Returns the node role for testing or observability purposes.
+     *
+     * @return current role
+     */
+    public Role role() {
+        return role;
+    }
+
+    /**
+     * Returns the last known leader identifier.
+     *
+     * @return leader identifier, may be {@code null}
+     */
+    public NodeId leaderId() {
+        return leaderId;
+    }
+
+    /**
+     * Returns the replicated commit index.
+     *
+     * @return commit index
+     */
+    public long commitIndex() {
+        return commitIndex;
+    }
+
+    private void applyInternal(final byte[] command, final CompletableFuture<ClientResponse> future) {
+        if (!running) {
+            future.complete(ClientResponse.failure(leaderId));
+            return;
+        }
+        if (role != Role.LEADER) {
+            future.complete(ClientResponse.notLeader(leaderId));
+            return;
+        }
+        final LogEntry entry = appendEntry(command);
+        clientResponses.put(entry.index(), future);
+        matchIndex.put(config.localNodeId(), log.lastIndex());
+        nextIndex.put(config.localNodeId(), log.lastIndex() + 1);
+        LOGGER.debug("Leader {} appended log entry index {} term {}", config.localNodeId(), entry.index(),
+                entry.term());
+        broadcastAppendEntries();
+    }
+
+    private void shutdownInternal() {
+        if (!running) {
+            shutdownFuture.complete(null);
+            return;
+        }
+        running = false;
+        LOGGER.info("Shutting down node {}", config.localNodeId());
+        if (tickerTask != null) {
+            tickerTask.cancel(false);
+        }
+        scheduler.shutdown();
+        clientResponses.values().forEach(future -> future.complete(ClientResponse.failure(leaderId)));
+        clientResponses.clear();
+        shutdownFuture.complete(null);
+    }
+
+    private void handleMessageInternal(final RaftMessage message) {
+        if (!running) {
+            return;
+        }
+        if (message instanceof RequestVoteRequest request) {
+            handleRequestVote(request);
+        } else if (message instanceof RequestVoteResponse response) {
+            handleRequestVoteResponse(response);
+        } else if (message instanceof AppendEntriesRequest request) {
+            handleAppendEntries(request);
+        } else if (message instanceof AppendEntriesResponse response) {
+            handleAppendEntriesResponse(response);
+        } else {
+            LOGGER.warn("Node {} received unsupported message {}", config.localNodeId(), message);
+        }
+    }
+
+    private void handleRequestVote(final RequestVoteRequest request) {
+        stepDownIfNeeded(request.term(), null);
+        final boolean upToDate = isCandidateLogUpToDate(request.lastLogIndex(), request.lastLogTerm());
+        final boolean termValid = request.term() == currentTerm;
+        boolean voteGranted = false;
+        if (termValid && upToDate && (votedFor == null || votedFor.equals(request.source()))) {
+            votedFor = request.source();
+            resetElectionTimer();
+            voteGranted = true;
+            LOGGER.debug("Node {} granted vote to {} for term {}", config.localNodeId(), request.source(),
+                    currentTerm);
+        }
+        transport.send(new RequestVoteResponse(config.localNodeId(), request.source(), currentTerm, voteGranted));
+    }
+
+    private void handleRequestVoteResponse(final RequestVoteResponse response) {
+        stepDownIfNeeded(response.term(), null);
+        if (role != Role.CANDIDATE || response.term() != currentTerm) {
+            return;
+        }
+        if (response.voteGranted()) {
+            votesGranted++;
+            LOGGER.debug("Candidate {} received vote from {} ({} votes)", config.localNodeId(), response.source(),
+                    votesGranted);
+            if (config.hasMajority(votesGranted)) {
+                becomeLeader();
+            }
+        }
+    }
+
+    private void handleAppendEntries(final AppendEntriesRequest request) {
+        stepDownIfNeeded(request.term(), request.source());
+        if (request.term() < currentTerm) {
+            transport.send(new AppendEntriesResponse(config.localNodeId(), request.source(), currentTerm, false,
+                    log.lastIndex()));
+            return;
+        }
+        leaderId = request.source();
+        resetElectionTimer();
+        boolean success = log.matches(request.prevLogIndex(), request.prevLogTerm());
+        long matchIdx = Math.min(request.prevLogIndex(), log.lastIndex());
+        if (success) {
+            log.appendFrom(request.entries());
+            matchIdx = log.lastIndex();
+            if (request.leaderCommit() > commitIndex) {
+                commitIndex = Math.min(request.leaderCommit(), log.lastIndex());
+                updateCommitGauge();
+                applyCommittedEntries();
+            }
+        }
+        transport.send(new AppendEntriesResponse(config.localNodeId(), request.source(), currentTerm, success,
+                matchIdx));
+    }
+
+    private void handleAppendEntriesResponse(final AppendEntriesResponse response) {
+        stepDownIfNeeded(response.term(), null);
+        if (role != Role.LEADER || response.term() != currentTerm) {
+            return;
+        }
+        if (response.success()) {
+            matchIndex.put(response.source(), response.matchIndex());
+            nextIndex.put(response.source(), response.matchIndex() + 1);
+            advanceCommitIndex();
+        } else {
+            final long currentNext = nextIndex.getOrDefault(response.source(), log.lastIndex() + 1);
+            final long decremented = Math.max(1L, Math.min(currentNext - 1, response.matchIndex() + 1));
+            nextIndex.put(response.source(), decremented);
+            sendAppendEntries(response.source());
+        }
+    }
+
+    private void advanceCommitIndex() {
+        long newCommit = commitIndex;
+        final long lastIndex = log.lastIndex();
+        for (long index = lastIndex; index > commitIndex; index--) {
+            if (log.termAt(index) != currentTerm) {
+                continue;
+            }
+            int replicated = 1; // self
+            for (final NodeId member : config.cluster()) {
+                if (member.equals(config.localNodeId())) {
+                    continue;
+                }
+                final long match = matchIndex.getOrDefault(member, 0L);
+                if (match >= index) {
+                    replicated++;
+                }
+            }
+            if (config.hasMajority(replicated)) {
+                newCommit = index;
+                break;
+            }
+        }
+        if (newCommit > commitIndex) {
+            commitIndex = newCommit;
+            updateCommitGauge();
+            applyCommittedEntries();
+        }
+    }
+
+    private void applyCommittedEntries() {
+        while (lastApplied < commitIndex) {
+            lastApplied++;
+            final LogEntry entry = log.entryAt(lastApplied);
+            byte[] output = null;
+            if (!entry.isNoOp()) {
+                try {
+                    output = stateMachine.apply(entry.command());
+                } catch (final Exception ex) {
+                    LOGGER.error("State machine error applying entry {}", entry.index(), ex);
+                    final CompletableFuture<ClientResponse> future = clientResponses.remove(entry.index());
+                    if (future != null) {
+                        future.complete(ClientResponse.failure(leaderId));
+                    }
+                    continue;
+                }
+            }
+            final CompletableFuture<ClientResponse> future = clientResponses.remove(entry.index());
+            if (future != null) {
+                future.complete(ClientResponse.success(output));
+            }
+        }
+    }
+
+    private boolean isCandidateLogUpToDate(final long candidateIndex, final long candidateTerm) {
+        final long localTerm = log.lastTerm();
+        if (candidateTerm != localTerm) {
+            return candidateTerm > localTerm;
+        }
+        return candidateIndex >= log.lastIndex();
+    }
+
+    private void startElection() {
+        role = Role.CANDIDATE;
+        updateRoleGauge();
+        currentTerm++;
+        updateTermGauge();
+        votedFor = config.localNodeId();
+        leaderId = null;
+        votesGranted = 1;
+        resetElectionTimer();
+        LOGGER.info("Node {} starting election for term {}", config.localNodeId(), currentTerm);
+        for (final NodeId member : config.cluster()) {
+            if (member.equals(config.localNodeId())) {
+                continue;
+            }
+            final RequestVoteRequest request = new RequestVoteRequest(config.localNodeId(), member, currentTerm,
+                    log.lastIndex(), log.lastTerm());
+            transport.send(request);
+        }
+        if (config.hasMajority(votesGranted)) {
+            becomeLeader();
+        }
+    }
+
+    private void becomeLeader() {
+        role = Role.LEADER;
+        updateRoleGauge();
+        leaderId = config.localNodeId();
+        votesGranted = 0;
+        LOGGER.info("Node {} became leader for term {}", config.localNodeId(), currentTerm);
+        final LogEntry noop = appendEntry(null);
+        matchIndex.put(config.localNodeId(), noop.index());
+        nextIndex.put(config.localNodeId(), noop.index() + 1);
+        broadcastAppendEntries();
+    }
+
+    private void broadcastAppendEntries() {
+        for (final NodeId member : config.cluster()) {
+            if (member.equals(config.localNodeId())) {
+                continue;
+            }
+            sendAppendEntries(member);
+        }
+        heartbeatDeadlineNanos = now() + config.heartbeatInterval().toNanos();
+    }
+
+    private void sendAppendEntries(final NodeId member) {
+        final long nextIdx = nextIndex.getOrDefault(member, log.lastIndex() + 1);
+        final long prevIndex = Math.max(0L, nextIdx - 1);
+        final long prevTerm = log.termAt(prevIndex);
+        final List<LogEntry> entries = log.entriesFrom(nextIdx);
+        final AppendEntriesRequest request = new AppendEntriesRequest(config.localNodeId(), member, currentTerm,
+                prevIndex, prevTerm, entries, commitIndex);
+        transport.send(request);
+    }
+
+    private LogEntry appendEntry(final byte[] command) {
+        final long index = log.lastIndex() + 1;
+        final LogEntry entry = new LogEntry(index, currentTerm, command);
+        log.appendFrom(List.of(entry));
+        return entry;
+    }
+
+    private void resetElectionTimer() {
+        final Duration timeout = config.randomElectionTimeout(random);
+        electionDeadlineNanos = now() + timeout.toNanos();
+    }
+
+    private void onTick() {
+        execute(this::tickInternal);
+    }
+
+    private void tickInternal() {
+        if (!running) {
+            return;
+        }
+        final long now = now();
+        if (role == Role.LEADER) {
+            if (now >= heartbeatDeadlineNanos) {
+                broadcastAppendEntries();
+            }
+        } else {
+            if (now >= electionDeadlineNanos) {
+                startElection();
+            }
+        }
+    }
+
+    private void stepDownIfNeeded(final long term, final NodeId newLeader) {
+        if (term > currentTerm) {
+            currentTerm = term;
+            updateTermGauge();
+            votedFor = null;
+            becomeFollower(newLeader);
+        } else if (role == Role.CANDIDATE && term == currentTerm && newLeader != null) {
+            becomeFollower(newLeader);
+        }
+    }
+
+    private void becomeFollower(final NodeId newLeader) {
+        role = Role.FOLLOWER;
+        updateRoleGauge();
+        leaderId = newLeader;
+        votesGranted = 0;
+        resetElectionTimer();
+    }
+
+    private long now() {
+        return System.nanoTime();
+    }
+
+    private void updateRoleGauge() {
+        if (roleGauge != null) {
+            roleGauge.set(role.ordinal());
+        }
+    }
+
+    private void updateTermGauge() {
+        if (termGauge != null) {
+            termGauge.set(currentTerm);
+        }
+    }
+
+    private void updateCommitGauge() {
+        if (commitGauge != null) {
+            commitGauge.set(commitIndex);
+        }
+    }
+
+    private void execute(final Runnable action) {
+        if (scheduler.isShutdown()) {
+            LOGGER.warn("Scheduler for node {} is shut down", config.localNodeId());
+            return;
+        }
+        try {
+            scheduler.execute(() -> {
+                try {
+                    action.run();
+                } catch (final Exception ex) {
+                    LOGGER.error("Unhandled exception in Raft node {}", config.localNodeId(), ex);
+                }
+            });
+        } catch (final Exception ex) {
+            LOGGER.error("Failed to schedule action for node {}", config.localNodeId(), ex);
+        }
+    }
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/LogEntry.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/LogEntry.java
@@ -1,0 +1,96 @@
+package io.distributed.consensus.raft.core;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Immutable log entry replicated through the Raft protocol.
+ */
+public final class LogEntry {
+
+    private final long index;
+    private final long term;
+    private final byte[] command;
+
+    /**
+     * Creates a new log entry.
+     *
+     * @param index    sequential log index starting at 1
+     * @param term     Raft term during which the entry was created
+     * @param command  state machine command payload, {@code null} represents a no-op
+     */
+    public LogEntry(final long index, final long term, final byte[] command) {
+        if (index <= 0) {
+            throw new IllegalArgumentException("Index must be positive");
+        }
+        if (term < 0) {
+            throw new IllegalArgumentException("Term must be non-negative");
+        }
+        this.index = index;
+        this.term = term;
+        this.command = command == null ? null : command.clone();
+    }
+
+    /**
+     * Returns the log index.
+     *
+     * @return log index
+     */
+    public long index() {
+        return index;
+    }
+
+    /**
+     * Returns the term associated with this entry.
+     *
+     * @return term number
+     */
+    public long term() {
+        return term;
+    }
+
+    /**
+     * Returns the command payload.
+     *
+     * @return command bytes or {@code null} for a no-op
+     */
+    public byte[] command() {
+        return command == null ? null : command.clone();
+    }
+
+    /**
+     * Returns whether the entry is a no-operation marker.
+     *
+     * @return {@code true} when no command payload exists
+     */
+    public boolean isNoOp() {
+        return command == null;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof LogEntry other)) {
+            return false;
+        }
+        return index == other.index && term == other.term && Arrays.equals(command, other.command);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(index, term);
+        result = 31 * result + Arrays.hashCode(command);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "LogEntry{" +
+                "index=" + index +
+                ", term=" + term +
+                ", command=" + (command == null ? "<noop>" : (command.length + " bytes")) +
+                '}';
+    }
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/NodeId.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/NodeId.java
@@ -1,0 +1,50 @@
+package io.distributed.consensus.raft.core;
+
+import java.util.Objects;
+
+/**
+ * Immutable identifier for a node participating in the Raft cluster.
+ */
+public final class NodeId {
+
+    private final String value;
+
+    /**
+     * Creates a new node identifier.
+     *
+     * @param value textual representation of the node id
+     */
+    public NodeId(final String value) {
+        this.value = Objects.requireNonNull(value, "value");
+    }
+
+    /**
+     * Returns the textual identifier.
+     *
+     * @return node id value
+     */
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof NodeId nodeId)) {
+            return false;
+        }
+        return value.equals(nodeId.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftConfig.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftConfig.java
@@ -1,0 +1,237 @@
+package io.distributed.consensus.raft.core;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.random.RandomGenerator;
+
+/**
+ * Immutable configuration for a Raft node.
+ */
+public final class RaftConfig {
+
+    private final NodeId localNodeId;
+    private final Set<NodeId> cluster;
+    private final Duration heartbeatInterval;
+    private final Duration tickInterval;
+    private final Duration electionTimeoutMin;
+    private final Duration electionTimeoutMax;
+    private final int quorumSize;
+
+    private RaftConfig(final Builder builder) {
+        this.localNodeId = Objects.requireNonNull(builder.localNodeId, "localNodeId");
+        this.cluster = Collections.unmodifiableSet(new HashSet<>(builder.cluster));
+        this.heartbeatInterval = Objects.requireNonNull(builder.heartbeatInterval, "heartbeatInterval");
+        this.tickInterval = Objects.requireNonNull(builder.tickInterval, "tickInterval");
+        this.electionTimeoutMin = Objects.requireNonNull(builder.electionTimeoutMin, "electionTimeoutMin");
+        this.electionTimeoutMax = Objects.requireNonNull(builder.electionTimeoutMax, "electionTimeoutMax");
+        if (!cluster.contains(localNodeId)) {
+            throw new IllegalArgumentException("Cluster must include the local node id");
+        }
+        if (cluster.size() < 3) {
+            throw new IllegalArgumentException("Cluster must contain at least three nodes for fault tolerance");
+        }
+        if (!electionTimeoutMax.minus(electionTimeoutMin).isPositive()) {
+            throw new IllegalArgumentException("Election timeout max must be greater than min");
+        }
+        if (!heartbeatInterval.minus(tickInterval).isPositive() && !heartbeatInterval.equals(tickInterval)) {
+            throw new IllegalArgumentException("Heartbeat interval must be >= tick interval");
+        }
+        if (!electionTimeoutMin.minus(heartbeatInterval).isPositive()) {
+            throw new IllegalArgumentException("Election timeout must be greater than heartbeat interval");
+        }
+        if (tickInterval.isZero() || tickInterval.isNegative()) {
+            throw new IllegalArgumentException("Tick interval must be positive");
+        }
+        this.quorumSize = (cluster.size() / 2) + 1;
+    }
+
+    /**
+     * Returns a builder for the configuration.
+     *
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns the identifier of the local node.
+     *
+     * @return node identifier
+     */
+    public NodeId localNodeId() {
+        return localNodeId;
+    }
+
+    /**
+     * Returns the set of cluster members.
+     *
+     * @return immutable cluster view
+     */
+    public Set<NodeId> cluster() {
+        return cluster;
+    }
+
+    /**
+     * Returns the heartbeat interval used by leaders.
+     *
+     * @return heartbeat interval
+     */
+    public Duration heartbeatInterval() {
+        return heartbeatInterval;
+    }
+
+    /**
+     * Returns the scheduler tick interval.
+     *
+     * @return tick interval
+     */
+    public Duration tickInterval() {
+        return tickInterval;
+    }
+
+    /**
+     * Returns the minimum election timeout.
+     *
+     * @return minimum election timeout
+     */
+    public Duration electionTimeoutMin() {
+        return electionTimeoutMin;
+    }
+
+    /**
+     * Returns the maximum election timeout.
+     *
+     * @return maximum election timeout
+     */
+    public Duration electionTimeoutMax() {
+        return electionTimeoutMax;
+    }
+
+    /**
+     * Randomizes a new election timeout.
+     *
+     * @param random random generator used to select a timeout
+     * @return randomized election timeout
+     */
+    public Duration randomElectionTimeout(final RandomGenerator random) {
+        final long min = electionTimeoutMin.toNanos();
+        final long max = electionTimeoutMax.toNanos();
+        final long bound = Math.max(1L, max - min);
+        return Duration.ofNanos(min + random.nextLong(bound));
+    }
+
+    /**
+     * Returns the size of the cluster quorum.
+     *
+     * @return majority size
+     */
+    public int quorumSize() {
+        return quorumSize;
+    }
+
+    /**
+     * Computes whether the provided vote count represents a majority.
+     *
+     * @param votes number of affirmative votes
+     * @return {@code true} if the count is at least the quorum size
+     */
+    public boolean hasMajority(final int votes) {
+        return votes >= quorumSize;
+    }
+
+    /**
+     * Builder for {@link RaftConfig}.
+     */
+    public static final class Builder {
+
+        private NodeId localNodeId;
+        private final Set<NodeId> cluster = new HashSet<>();
+        private Duration heartbeatInterval = Duration.ofMillis(50);
+        private Duration tickInterval = Duration.ofMillis(10);
+        private Duration electionTimeoutMin = Duration.ofMillis(150);
+        private Duration electionTimeoutMax = Duration.ofMillis(300);
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the local node identifier.
+         *
+         * @param nodeId node identifier
+         * @return this builder
+         */
+        public Builder localNodeId(final NodeId nodeId) {
+            this.localNodeId = Objects.requireNonNull(nodeId, "nodeId");
+            this.cluster.add(nodeId);
+            return this;
+        }
+
+        /**
+         * Adds a cluster member.
+         *
+         * @param nodeId node identifier
+         * @return this builder
+         */
+        public Builder addClusterMember(final NodeId nodeId) {
+            this.cluster.add(Objects.requireNonNull(nodeId, "nodeId"));
+            return this;
+        }
+
+        /**
+         * Sets the heartbeat interval for leaders.
+         *
+         * @param interval heartbeat interval
+         * @return this builder
+         */
+        public Builder heartbeatInterval(final Duration interval) {
+            this.heartbeatInterval = Objects.requireNonNull(interval, "interval");
+            return this;
+        }
+
+        /**
+         * Sets the tick interval used for scheduling.
+         *
+         * @param interval tick interval
+         * @return this builder
+         */
+        public Builder tickInterval(final Duration interval) {
+            this.tickInterval = Objects.requireNonNull(interval, "interval");
+            return this;
+        }
+
+        /**
+         * Sets the minimum election timeout.
+         *
+         * @param timeout minimum timeout
+         * @return this builder
+         */
+        public Builder electionTimeoutMin(final Duration timeout) {
+            this.electionTimeoutMin = Objects.requireNonNull(timeout, "timeout");
+            return this;
+        }
+
+        /**
+         * Sets the maximum election timeout.
+         *
+         * @param timeout maximum timeout
+         * @return this builder
+         */
+        public Builder electionTimeoutMax(final Duration timeout) {
+            this.electionTimeoutMax = Objects.requireNonNull(timeout, "timeout");
+            return this;
+        }
+
+        /**
+         * Builds the configuration instance.
+         *
+         * @return immutable configuration
+         */
+        public RaftConfig build() {
+            return new RaftConfig(this);
+        }
+    }
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftEndpoint.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftEndpoint.java
@@ -1,0 +1,14 @@
+package io.distributed.consensus.raft.core;
+
+/**
+ * Receives Raft protocol messages from remote nodes.
+ */
+public interface RaftEndpoint {
+
+    /**
+     * Handles an inbound protocol message.
+     *
+     * @param message message received from a peer
+     */
+    void handleMessage(RaftMessage message);
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftLog.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftLog.java
@@ -1,0 +1,104 @@
+package io.distributed.consensus.raft.core;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * In-memory log storage used by the default Raft implementation.
+ */
+final class RaftLog {
+
+    private final List<LogEntry> entries = new ArrayList<>();
+
+    RaftLog() {
+        // Index 0 is an empty sentinel that simplifies arithmetic.
+        entries.add(null);
+    }
+
+    long lastIndex() {
+        return entries.size() - 1L;
+    }
+
+    long lastTerm() {
+        if (entries.size() <= 1) {
+            return 0L;
+        }
+        return entries.get(entries.size() - 1).term();
+    }
+
+    boolean hasEntry(final long index) {
+        return index >= 0 && index < entries.size();
+    }
+
+    long termAt(final long index) {
+        if (index == 0) {
+            return 0L;
+        }
+        if (!hasEntry(index)) {
+            throw new IllegalArgumentException("Missing log entry at index " + index);
+        }
+        final LogEntry entry = entries.get((int) index);
+        return entry == null ? 0L : entry.term();
+    }
+
+    boolean matches(final long index, final long term) {
+        if (index == 0) {
+            return term == 0L;
+        }
+        if (!hasEntry(index)) {
+            return false;
+        }
+        final LogEntry entry = entries.get((int) index);
+        return entry != null && entry.term() == term;
+    }
+
+    void appendFrom(final List<LogEntry> newEntries) {
+        for (final LogEntry entry : newEntries) {
+            ensureSequential(entry);
+            if (!hasEntry(entry.index())) {
+                entries.add(entry);
+                continue;
+            }
+            final LogEntry existing = entries.get((int) entry.index());
+            if (existing != null && existing.term() == entry.term()) {
+                continue;
+            }
+            truncate(entry.index() - 1);
+            entries.add(entry);
+        }
+    }
+
+    List<LogEntry> entriesFrom(final long startIndex) {
+        if (startIndex >= entries.size()) {
+            return List.of();
+        }
+        return Collections.unmodifiableList(new ArrayList<>(entries.subList((int) startIndex, entries.size())));
+    }
+
+    LogEntry entryAt(final long index) {
+        if (!hasEntry(index)) {
+            throw new IllegalArgumentException("Missing log entry at index " + index);
+        }
+        final LogEntry entry = entries.get((int) index);
+        if (entry == null) {
+            throw new IllegalStateException("Index 0 is reserved for sentinel usage");
+        }
+        return entry;
+    }
+
+    void truncate(final long lastIndexToKeep) {
+        final int size = entries.size();
+        final int targetSize = (int) Math.max(1L, lastIndexToKeep + 1);
+        for (int i = size - 1; i >= targetSize; i--) {
+            entries.remove(i);
+        }
+    }
+
+    private void ensureSequential(final LogEntry entry) {
+        final long expectedIndex = entries.size();
+        if (entry.index() > expectedIndex) {
+            throw new IllegalArgumentException("Gap detected while appending log entry " + entry.index());
+        }
+    }
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftMessage.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftMessage.java
@@ -1,0 +1,22 @@
+package io.distributed.consensus.raft.core;
+
+/**
+ * Base marker interface for all Raft protocol messages.
+ */
+public sealed interface RaftMessage permits AppendEntriesRequest, AppendEntriesResponse,
+        RequestVoteRequest, RequestVoteResponse {
+
+    /**
+     * Returns the message source.
+     *
+     * @return source node identifier
+     */
+    NodeId source();
+
+    /**
+     * Returns the destination node identifier.
+     *
+     * @return destination node identifier
+     */
+    NodeId destination();
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftNode.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftNode.java
@@ -1,0 +1,29 @@
+package io.distributed.consensus.raft.core;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Public API for interacting with a Raft node.
+ */
+public interface RaftNode {
+
+    /**
+     * Starts the node's internal event loop.
+     */
+    void start();
+
+    /**
+     * Submits a command for replication through the cluster.
+     *
+     * @param command state machine command payload
+     * @return asynchronous response completed when the command commits
+     */
+    CompletableFuture<ClientResponse> apply(byte[] command);
+
+    /**
+     * Initiates a graceful shutdown.
+     *
+     * @return completion stage resolved when shutdown finishes
+     */
+    CompletableFuture<Void> shutdown();
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftTransport.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/RaftTransport.java
@@ -1,0 +1,15 @@
+package io.distributed.consensus.raft.core;
+
+/**
+ * Abstraction used by {@link DefaultRaftNode} to deliver protocol messages to peers.
+ */
+@FunctionalInterface
+public interface RaftTransport {
+
+    /**
+     * Sends an outbound message to the specified peer.
+     *
+     * @param message protocol message to deliver
+     */
+    void send(RaftMessage message);
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/RequestVoteRequest.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/RequestVoteRequest.java
@@ -1,0 +1,23 @@
+package io.distributed.consensus.raft.core;
+
+/**
+ * RequestVote RPC issued by candidates to solicit leadership votes.
+ */
+public record RequestVoteRequest(NodeId source, NodeId destination, long term, long lastLogIndex,
+                                 long lastLogTerm) implements RaftMessage {
+
+    /**
+     * Creates a request vote RPC.
+     */
+    public RequestVoteRequest {
+        if (term < 0) {
+            throw new IllegalArgumentException("Term must be non-negative");
+        }
+        if (lastLogIndex < 0) {
+            throw new IllegalArgumentException("Last log index must be non-negative");
+        }
+        if (lastLogTerm < 0) {
+            throw new IllegalArgumentException("Last log term must be non-negative");
+        }
+    }
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/RequestVoteResponse.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/RequestVoteResponse.java
@@ -1,0 +1,17 @@
+package io.distributed.consensus.raft.core;
+
+/**
+ * Response to a {@link RequestVoteRequest} RPC.
+ */
+public record RequestVoteResponse(NodeId source, NodeId destination, long term, boolean voteGranted)
+        implements RaftMessage {
+
+    /**
+     * Creates a request vote response.
+     */
+    public RequestVoteResponse {
+        if (term < 0) {
+            throw new IllegalArgumentException("Term must be non-negative");
+        }
+    }
+}

--- a/raft-core/src/main/java/io/distributed/consensus/raft/core/StateMachine.java
+++ b/raft-core/src/main/java/io/distributed/consensus/raft/core/StateMachine.java
@@ -1,0 +1,15 @@
+package io.distributed.consensus.raft.core;
+
+/**
+ * Deterministic replicated state machine applied once entries are committed.
+ */
+public interface StateMachine {
+
+    /**
+     * Applies the provided command to the state machine.
+     *
+     * @param command user command payload, never {@code null}
+     * @return optional response payload, may be {@code null}
+     */
+    byte[] apply(byte[] command);
+}

--- a/raft-core/src/test/java/io/distributed/consensus/raft/core/DefaultRaftNodeClusterTest.java
+++ b/raft-core/src/test/java/io/distributed/consensus/raft/core/DefaultRaftNodeClusterTest.java
@@ -1,0 +1,154 @@
+package io.distributed.consensus.raft.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+final class DefaultRaftNodeClusterTest {
+
+    private final List<DefaultRaftNode> nodes = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        for (final DefaultRaftNode node : nodes) {
+            if (node != null) {
+                node.shutdown().orTimeout(5, TimeUnit.SECONDS).join();
+            }
+        }
+    }
+
+    @Test
+    void electsLeaderAndReplicatesLogEntries() throws Exception {
+        final NodeId n1 = new NodeId("n1");
+        final NodeId n2 = new NodeId("n2");
+        final NodeId n3 = new NodeId("n3");
+        final Set<NodeId> cluster = Set.of(n1, n2, n3);
+
+        final InMemoryTransport transport = new InMemoryTransport();
+
+        final RecordingStateMachine sm1 = new RecordingStateMachine();
+        final RecordingStateMachine sm2 = new RecordingStateMachine();
+        final RecordingStateMachine sm3 = new RecordingStateMachine();
+
+        final DefaultRaftNode node1 = createNode(n1, cluster, sm1, transport);
+        final DefaultRaftNode node2 = createNode(n2, cluster, sm2, transport);
+        final DefaultRaftNode node3 = createNode(n3, cluster, sm3, transport);
+        nodes.addAll(List.of(node1, node2, node3));
+
+        transport.register(n1, node1);
+        transport.register(n2, node2);
+        transport.register(n3, node3);
+
+        node1.start();
+        node2.start();
+        node3.start();
+
+        final DefaultRaftNode leader = awaitLeader(nodes, Duration.ofSeconds(5));
+        assertThat(leader).isNotNull();
+        assertThat(leader.role()).isEqualTo(DefaultRaftNode.Role.LEADER);
+
+        final String command = "set=x";
+        final CompletableFuture<ClientResponse> responseFuture = leader.apply(command.getBytes(StandardCharsets.UTF_8));
+        final ClientResponse response = responseFuture.get(5, TimeUnit.SECONDS);
+        assertThat(response.status()).isEqualTo(ClientResponse.Status.SUCCESS);
+        assertThat(new String(response.output(), StandardCharsets.UTF_8)).isEqualTo(command);
+
+        awaitCondition(() -> sm1.commands().size() == 1
+                && sm2.commands().size() == 1
+                && sm3.commands().size() == 1, Duration.ofSeconds(5));
+
+        assertThat(sm1.commands()).containsExactly(command);
+        assertThat(sm2.commands()).containsExactly(command);
+        assertThat(sm3.commands()).containsExactly(command);
+        awaitCondition(() -> nodes.stream().allMatch(node -> node.leaderId() != null), Duration.ofSeconds(2));
+    }
+
+    private static DefaultRaftNode createNode(final NodeId nodeId, final Set<NodeId> cluster,
+                                              final StateMachine stateMachine, final InMemoryTransport transport) {
+        final RaftConfig.Builder builder = RaftConfig.builder()
+                .localNodeId(nodeId)
+                .heartbeatInterval(Duration.ofMillis(40))
+                .tickInterval(Duration.ofMillis(10))
+                .electionTimeoutMin(Duration.ofMillis(120))
+                .electionTimeoutMax(Duration.ofMillis(240));
+        for (final NodeId member : cluster) {
+            if (!member.equals(nodeId)) {
+                builder.addClusterMember(member);
+            }
+        }
+        final RaftConfig config = builder.build();
+        final DefaultRaftNode node = DefaultRaftNode.create(config, stateMachine, transport);
+        return node;
+    }
+
+    private static DefaultRaftNode awaitLeader(final List<DefaultRaftNode> nodes, final Duration timeout)
+            throws InterruptedException {
+        final long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            for (final DefaultRaftNode node : nodes) {
+                if (node.role() == DefaultRaftNode.Role.LEADER) {
+                    return node;
+                }
+            }
+            Thread.sleep(20L);
+        }
+        throw new AssertionError("Leader was not elected within timeout");
+    }
+
+    private static void awaitCondition(final BooleanSupplier condition, final Duration timeout)
+            throws InterruptedException {
+        final long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(10L);
+        }
+        throw new AssertionError("Condition was not satisfied before timeout");
+    }
+
+    private static final class RecordingStateMachine implements StateMachine {
+
+        private final List<String> commands = new ArrayList<>();
+
+        @Override
+        public synchronized byte[] apply(final byte[] command) {
+            final String value = new String(command, StandardCharsets.UTF_8);
+            commands.add(value);
+            return command.clone();
+        }
+
+        synchronized List<String> commands() {
+            return List.copyOf(commands);
+        }
+    }
+
+    private static final class InMemoryTransport implements RaftTransport {
+
+        private final Map<NodeId, RaftEndpoint> endpoints = new ConcurrentHashMap<>();
+
+        void register(final NodeId nodeId, final RaftEndpoint endpoint) {
+            endpoints.put(nodeId, endpoint);
+        }
+
+        @Override
+        public void send(final RaftMessage message) {
+            final RaftEndpoint endpoint = endpoints.get(message.destination());
+            if (endpoint == null) {
+                throw new IllegalStateException("No endpoint registered for " + message.destination());
+            }
+            endpoint.handleMessage(message);
+        }
+    }
+}

--- a/raft-core/src/test/java/io/distributed/consensus/raft/core/RaftLogTest.java
+++ b/raft-core/src/test/java/io/distributed/consensus/raft/core/RaftLogTest.java
@@ -1,0 +1,30 @@
+package io.distributed.consensus.raft.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class RaftLogTest {
+
+    @Test
+    void replacesConflictingEntries() {
+        final RaftLog log = new RaftLog();
+        log.appendFrom(List.of(
+                new LogEntry(1, 1, "one".getBytes(StandardCharsets.UTF_8)),
+                new LogEntry(2, 1, "two".getBytes(StandardCharsets.UTF_8))));
+        assertThat(log.lastIndex()).isEqualTo(2);
+        assertThat(log.matches(2, 1)).isTrue();
+
+        log.appendFrom(List.of(
+                new LogEntry(2, 2, "two-alt".getBytes(StandardCharsets.UTF_8)),
+                new LogEntry(3, 2, "three".getBytes(StandardCharsets.UTF_8))));
+
+        assertThat(log.lastIndex()).isEqualTo(3);
+        assertThat(log.matches(2, 2)).isTrue();
+        assertThat(log.matches(3, 2)).isTrue();
+        assertThat(new String(log.entryAt(2).command(), StandardCharsets.UTF_8)).isEqualTo("two-alt");
+        assertThat(new String(log.entryAt(3).command(), StandardCharsets.UTF_8)).isEqualTo("three");
+    }
+}


### PR DESCRIPTION
## Summary
- add a production-ready DefaultRaftNode with RaftConfig, log management, and client messaging to drive leader election and log replication
- define protocol message types, client responses, and transports to integrate the Raft core module
- cover the engine with an in-memory cluster test and log conflict unit test to validate replication behaviour

## Testing
- mvn -pl raft-core test *(fails: cannot download Maven BOMs because the build environment blocks outbound network access)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5d8be85c83308d86d215da5ba566