### PR TITLE
Security: fix secret handling and lock down @claude workflows

### DIFF
--- a/.github/actions/configure-ai/action.yml
+++ b/.github/actions/configure-ai/action.yml
@@ -1,5 +1,5 @@
 name: Configure AI credentials
-description: Claude OAuth first, Ollama Cloud fallback, then Anthropic API key.
+description: Select auth provider and set non-secret model endpoints only. Never writes secrets to GITHUB_ENV.
 
 inputs:
   claude_code_oauth_token:
@@ -7,46 +7,50 @@ inputs:
     required: false
     default: ""
   ollama_api_key:
-    description: Fallback Ollama Cloud API key (also wires OpenAI-compatible env for app tests)
+    description: Fallback Ollama Cloud API key
     required: false
     default: ""
   anthropic_api_key:
-    description: Fallback Anthropic API key when OAuth and Ollama are unavailable
+    description: Fallback Anthropic API key
     required: false
     default: ""
+
+outputs:
+  provider:
+    description: Selected auth provider
+    value: ${{ steps.select.outputs.provider }}
 
 runs:
   using: composite
   steps:
-    - shell: bash
+    - id: select
+      shell: bash
       env:
-        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
-        OLLAMA_API_KEY: ${{ inputs.ollama_api_key }}
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        HAS_OAUTH: ${{ inputs.claude_code_oauth_token != '' }}
+        HAS_OLLAMA: ${{ inputs.ollama_api_key != '' }}
+        HAS_ANTHROPIC: ${{ inputs.anthropic_api_key != '' }}
       run: |
         set -euo pipefail
 
-        if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
-          echo "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}" >> "$GITHUB_ENV"
+        if [ "$HAS_OAUTH" = "true" ]; then
+          echo "provider=claude-oauth" >> "$GITHUB_OUTPUT"
           echo "ai_provider=claude-oauth" >> "$GITHUB_ENV"
-        elif [ -n "${OLLAMA_API_KEY}" ]; then
+        elif [ "$HAS_OLLAMA" = "true" ]; then
+          echo "provider=ollama-cloud" >> "$GITHUB_OUTPUT"
           {
+            echo "ai_provider=ollama-cloud"
             echo "ANTHROPIC_BASE_URL=https://ollama.com"
-            echo "ANTHROPIC_AUTH_TOKEN=${OLLAMA_API_KEY}"
-            echo "ANTHROPIC_API_KEY="
             echo "ANTHROPIC_DEFAULT_SONNET_MODEL=glm-5:cloud"
             echo "ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5:cloud"
-            echo "OPENAI_API_KEY=${OLLAMA_API_KEY}"
             echo "OPENAI_BASE_URL=https://ollama.com/v1"
-            echo "OLLAMA_API_KEY=${OLLAMA_API_KEY}"
             echo "OLLAMA_BASE_URL=https://ollama.com/v1"
             echo "OLLAMA_MODEL=gpt-oss:120b"
             echo "OPENAI_MODEL=gpt-oss:120b"
-            echo "ai_provider=ollama-cloud"
           } >> "$GITHUB_ENV"
-        elif [ -n "${ANTHROPIC_API_KEY}" ]; then
-          echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" >> "$GITHUB_ENV"
+        elif [ "$HAS_ANTHROPIC" = "true" ]; then
+          echo "provider=anthropic-api" >> "$GITHUB_OUTPUT"
           echo "ai_provider=anthropic-api" >> "$GITHUB_ENV"
         else
+          echo "provider=none" >> "$GITHUB_OUTPUT"
           echo "ai_provider=none" >> "$GITHUB_ENV"
         fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,16 +47,21 @@ jobs:
       - name: Claude review
         uses: anthropics/claude-code-action@v1
         env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.OLLAMA_API_KEY }}
           ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
-          ANTHROPIC_AUTH_TOKEN: ${{ env.ANTHROPIC_AUTH_TOKEN }}
           ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ env.ANTHROPIC_DEFAULT_SONNET_MODEL }}
           ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ env.ANTHROPIC_DEFAULT_OPUS_MODEL }}
-          OLLAMA_API_KEY: ${{ env.OLLAMA_API_KEY }}
-          OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
+          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           OPENAI_BASE_URL: ${{ env.OPENAI_BASE_URL }}
+          OLLAMA_BASE_URL: ${{ env.OLLAMA_BASE_URL }}
+          OLLAMA_MODEL: ${{ env.OLLAMA_MODEL }}
+          OPENAI_MODEL: ${{ env.OPENAI_MODEL }}
         with:
-          claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
-          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |
             Review PR #${{ inputs.pr_number }} for raft-consensus.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,10 +17,32 @@ concurrency:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (
+          github.event_name == 'issue_comment' &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        ) ||
+        (
+          github.event_name == 'pull_request_review_comment' &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        ) ||
+        (
+          github.event_name == 'pull_request_review' &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        ) ||
+        (
+          github.event_name == 'issues' &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+        )
+      ) &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -45,16 +67,21 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.OLLAMA_API_KEY }}
           ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
-          ANTHROPIC_AUTH_TOKEN: ${{ env.ANTHROPIC_AUTH_TOKEN }}
           ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ env.ANTHROPIC_DEFAULT_SONNET_MODEL }}
           ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ env.ANTHROPIC_DEFAULT_OPUS_MODEL }}
-          OLLAMA_API_KEY: ${{ env.OLLAMA_API_KEY }}
-          OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
+          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           OPENAI_BASE_URL: ${{ env.OPENAI_BASE_URL }}
+          OLLAMA_BASE_URL: ${{ env.OLLAMA_BASE_URL }}
+          OLLAMA_MODEL: ${{ env.OLLAMA_MODEL }}
+          OPENAI_MODEL: ${{ env.OPENAI_MODEL }}
         with:
-          claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
-          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |
             You are the on-call engineer for raft-consensus.


### PR DESCRIPTION
## Summary
- Stop writing API keys into GITHUB_ENV via shell echo in configure-ai
- Pass secrets only through masked `${{ secrets.* }}` on Claude steps
- Restrict `@claude` to OWNER/MEMBER/COLLABORATOR and block fork PR triggers
- Remove sync-ollama-secret.sh pattern that piped keys from local env files

## Required follow-up
Rotate any Ollama/Anthropic keys that were previously set via local `.env` piping and re-enter them only through GitHub Settings → Secrets.


Made with [Cursor](https://cursor.com)